### PR TITLE
Add test to reproduce 2 level array bug for Spark

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -339,8 +339,16 @@ public abstract class BaseParquetReaders<T> {
 
       String[] repeatedPath = currentPath();
 
-      int repeatedD = type.getMaxDefinitionLevel(repeatedPath) - 1;
-      int repeatedR = type.getMaxRepetitionLevel(repeatedPath) - 1;
+      int repeatedD;
+      int repeatedR;
+
+      if (ParquetSchemaUtil.isOldListElementType(array)) {
+        repeatedD = type.getMaxDefinitionLevel(repeatedPath);
+        repeatedR = type.getMaxRepetitionLevel(repeatedPath);
+      } else {
+        repeatedD = type.getMaxDefinitionLevel(repeatedPath) - 1;
+        repeatedR = type.getMaxRepetitionLevel(repeatedPath);
+      }
 
       Type elementType = ParquetSchemaUtil.determineListElementType(array);
       int elementD = type.getMaxDefinitionLevel(path(elementType.getName())) - 1;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
@@ -176,7 +176,7 @@ public class ParquetSchemaUtil {
 
   // Parquet LIST backwards-compatibility rules.
   // https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#backward-compatibility-rules
-  static boolean isOldListElementType(GroupType list) {
+  public static boolean isOldListElementType(GroupType list) {
     Type repeatedType = list.getFields().get(0);
     String parentName = list.getName();
 

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
@@ -33,6 +33,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
@@ -47,7 +48,6 @@ import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.IntegerType;
@@ -200,23 +200,64 @@ public class TestParquet {
             .build();
 
     GenericRecordBuilder recordBuilder = new GenericRecordBuilder(avroSchema);
-    List<ByteBuffer> expectedByteList = Lists.newArrayList();
-    byte[] expectedByte = {0x00, 0x01};
-    ByteBuffer expectedBinary = ByteBuffer.wrap(expectedByte);
-    expectedByteList.add(expectedBinary);
-    recordBuilder.set("arraybytes", expectedByteList);
-    recordBuilder.set("topbytes", expectedBinary);
-    GenericData.Record expectedRecord = recordBuilder.build();
+    // Record 1: single element list, topbytes present
+    byte[] b1 = {0x00, 0x01};
+    ByteBuffer expectedBinary1 = ByteBuffer.wrap(b1);
+    List<ByteBuffer> expectedByteList1 = Collections.singletonList(expectedBinary1);
+    recordBuilder.set("arraybytes", expectedByteList1);
+    recordBuilder.set("topbytes", expectedBinary1);
+    writer.write(recordBuilder.build());
 
-    writer.write(expectedRecord);
+    // Record 2: empty list, topbytes null
+    recordBuilder = new GenericRecordBuilder(avroSchema);
+    recordBuilder.set("arraybytes", Collections.emptyList());
+    recordBuilder.set("topbytes", null);
+    writer.write(recordBuilder.build());
+
+    // Record 3: multi-element list, different topbytes
+    byte[] b2a = new byte[] {0x02, 0x03};
+    byte[] b2b = new byte[] {0x04, 0x05};
+    byte[] top = new byte[] {0x06, 0x07};
+    ByteBuffer expectedBinary2 = ByteBuffer.wrap(top);
+    List<ByteBuffer> expectedByteList2 = Arrays.asList(ByteBuffer.wrap(b2a), ByteBuffer.wrap(b2b));
+    recordBuilder = new GenericRecordBuilder(avroSchema);
+    recordBuilder.set("arraybytes", expectedByteList2);
+    recordBuilder.set("topbytes", expectedBinary2);
+    writer.write(recordBuilder.build());
+
+    // Record 4: null list (arraybytes omitted), topbytes present
+    recordBuilder = new GenericRecordBuilder(avroSchema);
+    recordBuilder.set("arraybytes", null);
+    recordBuilder.set("topbytes", expectedBinary1);
+    writer.write(recordBuilder.build());
+
     writer.close();
 
-    GenericData.Record recordRead =
-        Iterables.getOnlyElement(
+    List<GenericData.Record> recordsRead =
+        Lists.newArrayList(
             Parquet.read(Files.localInput(testFile)).project(schema).callInit().build());
 
-    assertThat(recordRead.get("arraybytes")).isEqualTo(expectedByteList);
-    assertThat(recordRead.get("topbytes")).isEqualTo(expectedBinary);
+    assertThat(recordsRead).hasSize(4);
+
+    // Record 1 assertions
+    GenericData.Record r1 = recordsRead.get(0);
+    assertThat(r1.get("arraybytes")).isEqualTo(expectedByteList1);
+    assertThat(r1.get("topbytes")).isEqualTo(expectedBinary1);
+
+    // Record 2 assertions
+    GenericData.Record r2 = recordsRead.get(1);
+    assertThat((List) r2.get("arraybytes")).isEmpty();
+    assertThat(r2.get("topbytes")).isNull();
+
+    // Record 3 assertions
+    GenericData.Record r3 = recordsRead.get(2);
+    assertThat(r3.get("arraybytes")).isEqualTo(expectedByteList2);
+    assertThat(r3.get("topbytes")).isEqualTo(expectedBinary2);
+
+    // Record 4 assertions
+    GenericData.Record r4 = recordsRead.get(3);
+    assertThat(r4.get("arraybytes")).isNull();
+    assertThat(r4.get("topbytes")).isEqualTo(expectedBinary1);
   }
 
   private Pair<File, Long> generateFile(

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -206,8 +206,16 @@ public class SparkParquetReaders {
         Types.ListType expectedList, GroupType array, ParquetValueReader<?> elementReader) {
       String[] repeatedPath = currentPath();
 
-      int repeatedD = type.getMaxDefinitionLevel(repeatedPath) - 1;
-      int repeatedR = type.getMaxRepetitionLevel(repeatedPath) - 1;
+      int repeatedD;
+      int repeatedR;
+
+      if (ParquetSchemaUtil.isOldListElementType(array)) {
+        repeatedD = type.getMaxDefinitionLevel(repeatedPath);
+        repeatedR = type.getMaxRepetitionLevel(repeatedPath);
+      } else {
+        repeatedD = type.getMaxDefinitionLevel(repeatedPath) - 1;
+        repeatedR = type.getMaxRepetitionLevel(repeatedPath);
+      }
 
       Type elementType = ParquetSchemaUtil.determineListElementType(array);
       int elementD = type.getMaxDefinitionLevel(path(elementType.getName())) - 1;

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -206,8 +206,16 @@ public class SparkParquetReaders {
         Types.ListType expectedList, GroupType array, ParquetValueReader<?> elementReader) {
       String[] repeatedPath = currentPath();
 
-      int repeatedD = type.getMaxDefinitionLevel(repeatedPath) - 1;
-      int repeatedR = type.getMaxRepetitionLevel(repeatedPath) - 1;
+      int repeatedD;
+      int repeatedR;
+
+      if (ParquetSchemaUtil.isOldListElementType(array)) {
+        repeatedD = type.getMaxDefinitionLevel(repeatedPath);
+        repeatedR = type.getMaxRepetitionLevel(repeatedPath);
+      } else {
+        repeatedD = type.getMaxDefinitionLevel(repeatedPath) - 1;
+        repeatedR = type.getMaxRepetitionLevel(repeatedPath);
+      }
 
       Type elementType = ParquetSchemaUtil.determineListElementType(array);
       int elementD = type.getMaxDefinitionLevel(path(elementType.getName())) - 1;

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -110,6 +110,12 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
     testImplementation (project(path: ':iceberg-open-api', configuration: 'testFixturesRuntimeElements')) {
       transitive = false
     }
+    testImplementation(libs.parquet.avro) {
+      exclude group: 'org.apache.avro', module: 'avro'
+      // already shaded by Parquet
+      exclude group: 'it.unimi.dsi'
+      exclude group: 'org.codehaus.jackson'
+    }
     testImplementation libs.sqlite.jdbc
     testImplementation libs.awaitility
     // runtime dependencies for running REST Catalog based integration test

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -195,8 +195,16 @@ public class SparkParquetReaders {
         Types.ListType expectedList, GroupType array, ParquetValueReader<?> elementReader) {
       String[] repeatedPath = currentPath();
 
-      int repeatedD = type.getMaxDefinitionLevel(repeatedPath) - 1;
-      int repeatedR = type.getMaxRepetitionLevel(repeatedPath) - 1;
+      int repeatedD;
+      int repeatedR;
+
+      if (ParquetSchemaUtil.isOldListElementType(array)) {
+        repeatedD = type.getMaxDefinitionLevel(repeatedPath);
+        repeatedR = type.getMaxRepetitionLevel(repeatedPath);
+      } else {
+        repeatedD = type.getMaxDefinitionLevel(repeatedPath) - 1;
+        repeatedR = type.getMaxRepetitionLevel(repeatedPath);
+      }
 
       Type elementType = ParquetSchemaUtil.determineListElementType(array);
       int elementD = type.getMaxDefinitionLevel(path(elementType.getName())) - 1;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReader.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReader.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.data;
 
 import static org.apache.iceberg.spark.data.TestHelpers.assertEqualsUnsafe;
+import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -26,10 +27,15 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
@@ -38,6 +44,7 @@ import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.data.IcebergGenerics;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.hadoop.HadoopTables;
@@ -51,6 +58,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
+import org.apache.parquet.avro.AvroParquetWriter;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.hadoop.util.HadoopOutputFile;
@@ -230,5 +238,81 @@ public class TestSparkParquetReader extends AvroDataTest {
     assertThatThrownBy(() -> writeAndValidate(writeSchema, expectedSchema))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Missing required field: missing_str");
+  }
+
+  @Test
+  public void testTwoLevelList() throws Exception {
+    // Mirror parquet TestParquet#testTwoLevelList: four record patterns
+    Schema schema =
+        new Schema(
+            optional(1, "arraybytes", Types.ListType.ofRequired(3, Types.BinaryType.get())),
+            optional(2, "topbytes", Types.BinaryType.get()));
+
+    org.apache.avro.Schema avroSchema = AvroSchemaUtil.convert(schema.asStruct());
+
+    File parquetFile = File.createTempFile("spark-two-level-list", ".parquet", temp.toFile());
+    assertThat(parquetFile.delete()).isTrue();
+
+    // Bytes used across records
+    byte[] b1 = new byte[] {0x00, 0x01};
+    ByteBuffer expectedBinary1 = ByteBuffer.wrap(b1);
+    List<ByteBuffer> expectedByteList1 = Collections.singletonList(expectedBinary1);
+
+    byte[] b2a = new byte[] {0x02, 0x03};
+    byte[] b2b = new byte[] {0x04, 0x05};
+    byte[] top = new byte[] {0x06, 0x07};
+    ByteBuffer expectedBinary2 = ByteBuffer.wrap(top);
+    List<ByteBuffer> expectedByteList2 = Arrays.asList(ByteBuffer.wrap(b2a), ByteBuffer.wrap(b2b));
+
+    List<GenericData.Record> expectedRecords = Lists.newArrayList();
+
+    try (ParquetWriter<GenericRecord> writer =
+        AvroParquetWriter.<GenericRecord>builder(
+                new org.apache.hadoop.fs.Path(parquetFile.getAbsolutePath()))
+            .withSchema(avroSchema)
+            .withDataModel(GenericData.get())
+            .config("parquet.avro.add-list-element-records", "true")
+            .config("parquet.avro.write-old-list-structure", "true")
+            .build()) {
+      GenericRecordBuilder builder = new GenericRecordBuilder(avroSchema);
+
+      // Record 1: single element list, topbytes present
+      builder.set("arraybytes", expectedByteList1);
+      builder.set("topbytes", expectedBinary1);
+      GenericData.Record r1 = builder.build();
+      writer.write(r1);
+      expectedRecords.add(r1);
+
+      // Record 2: empty list, topbytes null
+      builder = new GenericRecordBuilder(avroSchema);
+      builder.set("arraybytes", Collections.emptyList());
+      builder.set("topbytes", null);
+      GenericData.Record r2 = builder.build();
+      writer.write(r2);
+      expectedRecords.add(r2);
+
+      // Record 3: multi-element list, different topbytes
+      builder = new GenericRecordBuilder(avroSchema);
+      builder.set("arraybytes", expectedByteList2);
+      builder.set("topbytes", expectedBinary2);
+      GenericData.Record r3 = builder.build();
+      writer.write(r3);
+      expectedRecords.add(r3);
+
+      // Record 4: null list (arraybytes omitted), topbytes present
+      builder = new GenericRecordBuilder(avroSchema);
+      builder.set("arraybytes", null);
+      builder.set("topbytes", expectedBinary1);
+      GenericData.Record r4 = builder.build();
+      writer.write(r4);
+      expectedRecords.add(r4);
+    }
+
+    List<InternalRow> rows = rowsFromFile(Files.localInput(parquetFile), schema);
+    assertThat(rows).hasSize(expectedRecords.size());
+
+    for (int i = 0; i < expectedRecords.size(); i++) {
+      assertEqualsUnsafe(schema.asStruct(), expectedRecords.get(i), rows.get(i));
+    }
   }
 }


### PR DESCRIPTION
The same test can run successfully with Iceberg Parquet reader, but not Spark Parquet reader.